### PR TITLE
Se incrementa tamaño de buffer

### DIFF
--- a/Adafruit_MQTT.h
+++ b/Adafruit_MQTT.h
@@ -125,7 +125,9 @@
 #define SUBSCRIPTIONDATALEN 20
 #else
 #define MAXSUBSCRIPTIONS 15
-#define SUBSCRIPTIONDATALEN 100
+#ifndef SUBSCRIPTIONDATALEN
+  #define SUBSCRIPTIONDATALEN 8192
+#endif
 #endif
 
 class AdafruitIO_MQTT; // forward decl


### PR DESCRIPTION
Se incrementa tamaño de buffer de suscripción para recibir jsons más grandes desde tópicos. El tamaño por defecto es 8192 pero se puede cambiar con build macros